### PR TITLE
TemplateProvider Caching and DotLiquid upgrade

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
     {
         private const string MetadataFileName = "metadata.json";
         private static readonly List<string> CcdaExtensions = new List<string> { ".ccda", ".xml" };
+        private static Dictionary<string, TemplateProvider> CcdaTemplateProviderCache = new Dictionary<string, TemplateProvider>();
 
         public static void Convert(ConverterOptions options)
         {
@@ -144,10 +145,23 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
             return dataType switch
             {
                 DataType.Hl7v2 => new TemplateProvider(templateDirectory, DataType.Hl7v2),
-                DataType.Ccda => new TemplateProvider(templateDirectory, DataType.Ccda),
+                DataType.Ccda => GetCcdaTemplateProvider(templateDirectory),
                 DataType.Json => new TemplateProvider(templateDirectory, DataType.Json),
                 _ => throw new NotImplementedException($"The conversion from data type {dataType} to FHIR is not supported")
             };
+        }
+
+        private static TemplateProvider GetCcdaTemplateProvider(string templateDirectory)
+        {
+            if (CcdaTemplateProviderCache.ContainsKey(templateDirectory))
+            {
+                return CcdaTemplateProviderCache[templateDirectory];
+            }
+
+            // Create a new TemplateProvider and insert into the cache
+            var ccdaTP = new TemplateProvider(templateDirectory, DataType.Ccda);
+            CcdaTemplateProviderCache[templateDirectory] = ccdaTP;
+            return ccdaTP;
         }
 
         private static TraceInfo CreateTraceInfo(DataType dataType, bool isTraceInfo)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SectionFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SectionFiltersTests.cs
@@ -67,19 +67,19 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
             const string templateIdContent = "2.16.840.1.113883.10.20.22.2.6.1";
 
             // Empty data
-            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(new Hash(), templateIdContent));
+            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(new Dictionary<string, object>(), templateIdContent));
 
             // Empty template id content
-            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(Hash.FromDictionary(TestData), string.Empty));
+            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(TestData, string.Empty));
 
             // Valid data and template id content
-            var sections = Filters.GetFirstCcdaSectionsByTemplateId(Hash.FromDictionary(TestData), templateIdContent);
+            var sections = Filters.GetFirstCcdaSectionsByTemplateId(TestData, templateIdContent);
             Assert.Single(sections);
             Assert.Equal(5, ((Dictionary<string, object>)sections["2_16_840_1_113883_10_20_22_2_6_1"]).Count);
 
             // Null data or template id content
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstCcdaSectionsByTemplateId(null, templateIdContent));
-            Assert.Throws<NullReferenceException>(() => Filters.GetFirstCcdaSectionsByTemplateId(new Hash(), null));
+            Assert.Throws<NullReferenceException>(() => Filters.GetFirstCcdaSectionsByTemplateId(new Dictionary<string, object>(), null));
         }
 
         private static Dictionary<string, object> LoadTestData()

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SectionFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SectionFiltersTests.cs
@@ -67,19 +67,19 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
             const string templateIdContent = "2.16.840.1.113883.10.20.22.2.6.1";
 
             // Empty data
-            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(new Dictionary<string, object>(), templateIdContent));
+            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(new Hash(), templateIdContent));
 
             // Empty template id content
-            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(TestData, string.Empty));
+            Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(Hash.FromDictionary(TestData), string.Empty));
 
             // Valid data and template id content
-            var sections = Filters.GetFirstCcdaSectionsByTemplateId(TestData, templateIdContent);
+            var sections = Filters.GetFirstCcdaSectionsByTemplateId(Hash.FromDictionary(TestData), templateIdContent);
             Assert.Single(sections);
             Assert.Equal(5, ((Dictionary<string, object>)sections["2_16_840_1_113883_10_20_22_2_6_1"]).Count);
 
             // Null data or template id content
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstCcdaSectionsByTemplateId(null, templateIdContent));
-            Assert.Throws<NullReferenceException>(() => Filters.GetFirstCcdaSectionsByTemplateId(new Dictionary<string, object>(), null));
+            Assert.Throws<NullReferenceException>(() => Filters.GetFirstCcdaSectionsByTemplateId(new Hash(), null));
         }
 
         private static Dictionary<string, object> LoadTestData()

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SectionFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SectionFilters.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
     {
         private static readonly Regex NormalizeSectionNameRegex = new Regex("[^A-Za-z0-9]");
 
-        public static IDictionary<string, object> GetFirstCcdaSections(Hash data, string sectionNameContent)
+        public static IDictionary<string, object> GetFirstCcdaSections(IDictionary<string, object> data, string sectionNameContent)
         {
             var sectionLists = Filters.GetCcdaSectionLists(data, sectionNameContent);
             var result = new Dictionary<string, object>();
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             return result;
         }
 
-        public static IDictionary<string, object> GetCcdaSectionLists(Hash data, string sectionNameContent)
+        public static IDictionary<string, object> GetCcdaSectionLists(IDictionary<string, object> data, string sectionNameContent)
         {
             var result = new Dictionary<string, object>();
             var sectionNames = sectionNameContent.Split("|", StringSplitOptions.RemoveEmptyEntries);
@@ -67,12 +67,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             return result;
         }
 
-        public static IDictionary<string, object> GetFirstCcdaSectionsByTemplateId(Dictionary<string, object> data, string templateIdContent)
+        public static IDictionary<string, object> GetFirstCcdaSectionsByTemplateId(IDictionary<string, object> data, string templateIdContent)
         {
-            var hash = FromDictionary(data);
             var result = new Dictionary<string, object>();
             var templateIds = templateIdContent.Split("|", StringSplitOptions.RemoveEmptyEntries);
-            var components = GetComponents(hash);
+            var components = GetComponents(data);
 
             if (components == null)
             {
@@ -97,12 +96,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             return result;
         }
 
-        private static List<object> GetComponents(Hash data)
+        private static List<object> GetComponents(IDictionary<string, object> data)
         {
-            var dataComponents = (((data["ClinicalDocument"] as Hash)?
-                ["component"] as Hash)?
-                ["structuredBody"] as Hash)?
-                ["component"];
+            var dataComponents = (((data["ClinicalDocument"] as Dictionary<string, object>)?
+                .GetValueOrDefault("component") as Dictionary<string, object>)?
+                .GetValueOrDefault("structuredBody") as Dictionary<string, object>)?
+                .GetValueOrDefault("component");
 
             if (dataComponents == null)
             {
@@ -117,28 +116,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
         private static string NormalizeSectionName(string input)
         {
             return NormalizeSectionNameRegex.Replace(input, "_");
-        }
-
-        private static Hash FromDictionary(IDictionary<string, object> dictionary)
-        {
-            Hash result = new Hash();
-
-            foreach (var keyValue in dictionary)
-            {
-                if (keyValue.Value is IDictionary<string, object>)
-                {
-                    result.Add(keyValue.Key, FromDictionary((IDictionary<string, object>)keyValue.Value));
-                }
-                else
-                {
-                    result.Add(keyValue);
-                }
-            }
-
-            return result;
-            var hash = new Hash();
-            hash.Merge(dictionary);
-            return hash;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SectionFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SectionFilters.cs
@@ -67,11 +67,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
             return result;
         }
 
-        public static IDictionary<string, object> GetFirstCcdaSectionsByTemplateId(Hash data, string templateIdContent)
+        public static IDictionary<string, object> GetFirstCcdaSectionsByTemplateId(Dictionary<string, object> data, string templateIdContent)
         {
+            var hash = FromDictionary(data);
             var result = new Dictionary<string, object>();
             var templateIds = templateIdContent.Split("|", StringSplitOptions.RemoveEmptyEntries);
-            var components = GetComponents(data);
+            var components = GetComponents(hash);
 
             if (components == null)
             {
@@ -116,6 +117,28 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
         private static string NormalizeSectionName(string input)
         {
             return NormalizeSectionNameRegex.Replace(input, "_");
+        }
+
+        private static Hash FromDictionary(IDictionary<string, object> dictionary)
+        {
+            Hash result = new Hash();
+
+            foreach (var keyValue in dictionary)
+            {
+                if (keyValue.Value is IDictionary<string, object>)
+                {
+                    result.Add(keyValue.Key, FromDictionary((IDictionary<string, object>)keyValue.Value));
+                }
+                else
+                {
+                    result.Add(keyValue);
+                }
+            }
+
+            return result;
+            var hash = new Hash();
+            hash.Merge(dictionary);
+            return hash;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
-    <PackageReference Include="DotLiquid" Version="2.0.366" />
+    <PackageReference Include="DotLiquid" Version="2.2.656" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
Added caching of the CCDA TemplateProvider to prevent recompiling the liquid templates every call.

Upgraded DotLiquid dependency and made necessary code changes.